### PR TITLE
Handle case when `glue()` is called with empty inputs

### DIFF
--- a/R/officer.R
+++ b/R/officer.R
@@ -92,7 +92,7 @@ body_add_normal = function(doc, ..., .sep="", squish=TRUE) {
     if(all(lengths==1)){ #one or several vectors of length 1
         value = glue(..., .sep=.sep, .envir=parent.frame())
         if(squish) value = str_squish(value)
-        if(str_detect(value, "\\\\@ref\\((.*?)\\)")){
+        if(length(value) > 0 && str_detect(value, "\\\\@ref\\((.*?)\\)")){
             # doc = body_add_par(doc, "") %>% parse_reference(value)
             doc = body_add_par(doc, "") %>% parse_reference(value)
         } else{


### PR DESCRIPTION
glue 1.5.0 changes the behavior when called with completely empty
inputs.

Previous versions of glue returned `""`, e.g. a length 1 character
vector with an empty string as the value.

glue 1.5.0 instead returns `character(0)` vector, a 0 length character
vector.

The new behavior is more consistent with `paste0()`, which also returns
a 0 length character vector on empty input.

This change caused an example to fail with glue 1.5.0, which is fixed by
the changes in this commit.