### PR TITLE
Replace missings by iterating over list of level vectors

### DIFF
--- a/R/openxlsx.R
+++ b/R/openxlsx.R
@@ -78,7 +78,7 @@ addToWorksheet = function(wb, ct, sheetname, show_test_name = TRUE,
     has_test = attr(ct, "has_test")
     has_label = attr(ct, "has_label")
     by_label = attr(ct, "by_label")
-    by_levels = attr(ct, "by_levels") %>% lapply(replace_na, replace = "NA") %>% unlist()
+    by_levels = attr(ct, "by_levels") %>% map(replace_na, replace="NA") %>% unlist()
     multiple_by = length(attr(ct, "by_levels"))>1
     
     by = attr(ct, "by")

--- a/R/openxlsx.R
+++ b/R/openxlsx.R
@@ -78,7 +78,7 @@ addToWorksheet = function(wb, ct, sheetname, show_test_name = TRUE,
     has_test = attr(ct, "has_test")
     has_label = attr(ct, "has_label")
     by_label = attr(ct, "by_label")
-    by_levels = attr(ct, "by_levels") %>% replace_na("NA") %>% unlist()
+    by_levels = attr(ct, "by_levels") %>% lapply(replace_na, replace = "NA") %>% unlist()
     multiple_by = length(attr(ct, "by_levels"))>1
     
     by = attr(ct, "by")


### PR DESCRIPTION
We are planning on releasing tidyr 1.2.0 towards the end of this month.

We noticed in revdeps that this package was broken. An easy way to reproduce is to install the dev version of tidyr and run:

``` r
library(crosstable)
x2=crosstable(mtcars2, c(mpg, vs, gear), by=cyl, total=T)
wb3=as_workbook(x2, keep_id=FALSE)
#> Error: Can't convert `replace` <character> to match type of `data` <list>.
```

The problem comes down to the fact that you were passing `replace_na()` a list of character vectors and were expecting it to iterate through the list and replace on each element vector. That actually never worked (see below with the CRAN version of tidyr), but now you get an actual error.

``` r
x <- list(c("a", "b", NA), c("v", NA))

tidyr::replace_na(x, "NA")
#> [[1]]
#> [1] "a" "b" NA 
#> 
#> [[2]]
#> [1] "v" NA
```

This PR just manually iterates over the list, calling replace-na on each element.

This should work on both the current and development version of tidyr, so you should be able to go ahead and do a patch release. We would greatly appreciate if you could do this so we can release tidyr! Thank you!