### PR TITLE
Fix tests with testthat 3.1.2

### DIFF
--- a/tests/testthat/helper-init_dataset.R
+++ b/tests/testthat/helper-init_dataset.R
@@ -1,5 +1,5 @@
 
-Sys.setenv(LANG = "en")
+Sys.setenv(LANGUAGE = "en")
 Sys.setenv(TZ='Europe/Paris')
 
 options(stringsAsFactors = FALSE)


### PR DESCRIPTION
By setting `LANGUAGE`, not `LANG`. Confusingly `LANG` is supposed to be a locale `en_US`.  (I think you could probably also safely remove this setting because testthat 3.1.2 now does a better job of ensuring that error messages always appear in English).

I'm planning on submitting testthat to CRAN next week (Jan 21), so a speedy update would be much appreciated.