### PR TITLE
Fix for dev purrr

### DIFF
--- a/R/cross_numeric.R
+++ b/R/cross_numeric.R
@@ -112,6 +112,7 @@ summarize_numeric_factor = function(x, by, funs, funs_arg, showNA, total,
   }
 
   by(x[by_filter], by[by_filter], summarize_numeric_single, funs=funs, funs_arg=funs_arg) %>%
+    unclass() %>%
     imap_dfr(~{
       if(is.null(.x)) .x=summarize_numeric_single(numeric(0), funs=funs, funs_arg=funs_arg)
       mutate(.x, by=.y, .before=1)


### PR DESCRIPTION
by() can return either a list or an array, so this isn't bullet proof, but it does turn by objects back into a regular list.